### PR TITLE
Initialize blank VitePress scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,3 @@
-# wuhine
-Hello everyone, this is the repository of a website for ***wuhine***, both my English teacher and my great class teacher.
+# Blank VitePress Site
 
-You can access the site [here](https://wuhine.us.kg)
-
-## Greatful
-
-**magojohnji** - The main developer.
-
-**sakurayu** - The main developer.
-
-**GitHub** - Provide the free host.
-
-**CloudFlare** - Provide free cert, CDN and DNS settings.
-
-## LICENCE
-```
-Private LICENCE
-
-Class 5, Grade 1, Jiangdu High School, Yangzhou city, Jiangsu Province, China
-
-Nobody has the right to use, change or download the code, except all the students and wuhine individual in Class 5, Grade 1.
-```
+This branch contains a minimal VitePress scaffold.

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vitepress'
+
+export default defineConfig({
+  title: 'VitePress Site',
+  description: 'A blank VitePress site'
+})

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,3 @@
+# Hello
+
+A blank VitePress page.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "blank-vitepress-site",
+  "private": true,
+  "scripts": {
+    "docs:dev": "vitepress dev docs",
+    "docs:build": "vitepress build docs",
+    "docs:preview": "vitepress preview docs"
+  },
+  "devDependencies": {
+    "vitepress": "^1.3.4"
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal empty VitePress site scaffold in a dedicated branch to start documentation work without adding substantive content.
- Replace the existing README with a short note describing the branch purpose and include the minimal docs skeleton.

### Description
- Added a minimal `package.json` with `docs:dev`, `docs:build`, and `docs:preview` scripts and a `vitepress` devDependency.
- Added `docs/.vitepress/config.mts` with basic site `title` and `description` configuration.
- Added `docs/index.md` as a placeholder homepage for the VitePress site.
- Replaced `README.md` content with a short description indicating this branch contains a minimal VitePress scaffold.

### Testing
- Verified repository status with `git status --short --branch`, which completed successfully.
- Inspected the created files with `nl -ba README.md; nl -ba package.json; nl -ba docs/.vitepress/config.mts; nl -ba docs/index.md`, which showed the expected contents.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8b75638a0832c9ba7bb5a5b9ccd54)